### PR TITLE
Addresses are now in base32 + ED25119

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,10 +128,12 @@ dmypy.json
 
 *.pem
 
-Node/Accounts/
+Node/AccountsOld/
 
 Node/Accounts2/
 
 Node/encryptionCLient.py
 
 Node/encryption.py
+
+Node/Accounts/


### PR DESCRIPTION
MurraxCoin addresses are now base32 encodings of the public key + a 7 digit checksum.

MurraxCoin now uses curve ED25119 rather than P-256. This is due to reduced key size (32 bytes vs 64), allowing for a more compact address. Also, P-256 is not regarded as fully safe by https://safecurves.cr.yp.to/ , while ED25119 is.

Closes #13 