### PR TITLE
Block IDs are now BLAKE2b hashes of block contents.

### DIFF
--- a/Wallet/wallet.py
+++ b/Wallet/wallet.py
@@ -292,8 +292,10 @@ async def main():
             response = await wsRequest(f'{{"type": "getPrevious", "address": "{publicKeyStr}"}}')
             previous = json.loads(response)["link"]
 
-            data = {"type": "change", "address": publicKeyStr, "balance": balance, "representative": delegateAddress, "id": blockID, "previous": previous}
-
+            data = {"type": "change", "address": publicKeyStr, "balance": balance, "representative": delegateAddress, "previous": previous}
+            hasher = BLAKE2b.new(digest_bits=512)
+            blockID = hasher.update(json.dumps(data).encode("utf-8")).hexdigest()
+            data["id"] = blockID
             signature = await genSignature(data, privateKey)
             data["signature"] = signature
 


### PR DESCRIPTION
Block IDs are now BLAKE2b hashes of block contents, instead of a random 20 digit integer.

Closes #15